### PR TITLE
Revert node6 exponentiation breaking change

### DIFF
--- a/src/unpacker/feature.js
+++ b/src/unpacker/feature.js
@@ -18,7 +18,7 @@ function unpackSupport(cipher) {
   while (notes) {
     let note = Math.floor(Math.log(notes) / MATH2LOG) + 1
     notesArray.unshift(`#${note}`)
-    notes -= 2 ** (note - 1)
+    notes -= Math.pow(2, note - 1)
   }
 
   return stats.concat(notesArray).join(' ')


### PR DESCRIPTION
Changes proposed by this PR reverts code update that added the "**" operator in the unpackSupport function from feature.js

This operator has been introduced in node 7 and breaks node 6 projects that doesnt use the "--harmony" runtime flag

Since "**" is an equivalent to "Math.pow", it should still be okay to use it for compatibility with older projects