### PR TITLE
Add `shown` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In addition, the subset contains the `release_date` key with release dates (as t
 
 The `feature` method takes a file from `data/features` and converts it into
 something that more closely represents the `caniuse-db` format. Note that only
-the `title`, `stats` and `status` keys are kept from the original data.
+the `title`, `stats`, `status`, and `shown` keys are kept from the original data.
 
 
 ### `lite.features`

--- a/dist/unpacker/feature.js
+++ b/dist/unpacker/feature.js
@@ -27,7 +27,11 @@ function unpackSupport(cipher) {
 }
 
 function unpackFeature(packed) {
-  let unpacked = { status: statuses[packed.B], title: packed.C }
+  let unpacked = {
+    status: statuses[packed.B],
+    title: packed.C,
+    shown: packed.D
+  }
   unpacked.stats = Object.keys(packed.A).reduce((browserStats, key) => {
     let browser = packed.A[key]
     browserStats[browsers[key]] = Object.keys(browser).reduce(

--- a/src/feature.test.js
+++ b/src/feature.test.js
@@ -42,6 +42,7 @@ test('should be 1:1', () => {
     })
     equal(unpacked.status, data.status)
     equal(unpacked.title, data.title)
+    equal(unpacked.shown, data.shown)
   })
 })
 

--- a/src/lib/stringifyObject.js
+++ b/src/lib/stringifyObject.js
@@ -17,6 +17,8 @@ function stringifyRecursive(data) {
     return t.identifier('undefined')
   } else if (typeof data === 'string') {
     return t.stringLiteral(data)
+  } else if (typeof data === 'boolean') {
+    return t.booleanLiteral(data)
   } else if (typeof data === 'number') {
     return t.numericLiteral(data)
   } else if (Array.isArray(data)) {

--- a/src/packer/feature.js
+++ b/src/packer/feature.js
@@ -83,6 +83,7 @@ module.exports = async function packFeature() {
       )
       packed.B = parseDecimal(statusesInverted[contents.status])
       packed.C = contents.title
+      packed.D = contents.shown
       return fs.writeFile(
         path.join(__dirname, `../../data/features/${name}.js`),
         stringifyObject(packed)


### PR DESCRIPTION
This PR fixes #119, to add the `shown` key from caniuse to caniuse-lite.

Over on [web-platform-dx/feature-set](https://github.com/web-platform-dx/feature-set/), we're building a catalog of web platform features and cross-referencing specifications, caniuse, and mdn/browser-compat-data and other sources. With the `shown` key, we can avoid creating broken links to features on caniuse.com.

Thank you for considering this PR.