### PR TITLE
fix: re-add `git push` to check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,3 +59,6 @@ jobs:
       - name: Commit changes
         if: steps.caniuse.outputs.newVersion
         run: node ./commit.js
+      - name: Push changes
+        if: steps.caniuse.outputs.newVersion
+        run: git push --follow-tags


### PR DESCRIPTION
In 761b60ff, the `git push` was removed. This means the committed update
is now being lost since it never gets pushed anywhere.

This change reintroduces it without the clean-publish stuff.
