### PR TITLE
fix: use workflow_run for release workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,8 @@ jobs:
             github.com:443
             release-assets.githubusercontent.com:443
             registry.npmjs.org:443
+            results-receiver.actions.githubusercontent.com:443
+            *.blob.core.windows.net:443
             *.sigstore.dev:443
       - name: Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -62,3 +64,12 @@ jobs:
       - name: Push changes
         if: steps.caniuse.outputs.newVersion
         run: git push --follow-tags
+      - name: Write release marker
+        if: steps.caniuse.outputs.newVersion
+        run: echo true > should_release
+      - name: Upload release marker
+        if: steps.caniuse.outputs.newVersion
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: should_release
+          path: should_release

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,8 +21,6 @@ jobs:
             github.com:443
             release-assets.githubusercontent.com:443
             registry.npmjs.org:443
-            results-receiver.actions.githubusercontent.com:443
-            *.blob.core.windows.net:443
             *.sigstore.dev:443
       - name: Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,29 @@
 name: Release
 on:
-  push:
-    tags:
-      - '*'
+  workflow_run:
+    workflows: ['Check']
+    types:
+      - completed
 jobs:
+  check:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      release: ${{ steps.marker.outcome }}
+    steps:
+      - name: Download release marker
+        id: marker
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: should_release
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
   publish:
+    needs: check
+    if: needs.check.outputs.release == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
It seems GitHub doesn't respect tag triggers if the thing tagging it is
another workflow (to prevent recursion, inf. loops).

So this changes it to use `workflow_run` instead. That means the release
workflow will run only when the `check` workflow has finished.

The `check` workflow now stores a `should_release` artifact (bound to
that run). The `release` workflow checks this artifact's existence to
decide if to publish or not.

@ai I could do with another pair of eyes on this since its more change than I hoped for.
